### PR TITLE
Fix postgres connection string

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ prometheus_postgres_exporter_env_variable_pg_exporter_auto_discover_databases: t
 prometheus_postgres_exporter_env_variable_pg_exporter_web_listen_address: ":{{ prometheus_postgres_exporter_port }}"
 
 # Controls the DATA_SOURCE_NAME environment variable
-prometheus_postgres_exporter_env_variable_data_source_name: "postgresql://{{ prometheus_postgres_exporter_database_username }}:{{ prometheus_postgres_exporter_database_password }}@{{ prometheus_postgres_exporter_database_hostname }}:5432/{{ prometheus_postgres_exporter_database_name }}{{ postgres_exporter_database_hostname }}:{{ postgres_exporter_database_port }}/{{ postgres_exporter_database_name }}{{ '?sslmode=disable' if not prometeus_postgres_exporter_database_ssl else '' }}"
+prometheus_postgres_exporter_env_variable_data_source_name: "postgresql://{{ prometheus_postgres_exporter_database_username }}:{{ prometheus_postgres_exporter_database_password }}@{{ prometheus_postgres_exporter_database_hostname }}:{{ prometheus_postgres_exporter_database_port }}/{{ prometheus_postgres_exporter_database_name }}{{ '?sslmode=disable' if not prometeus_postgres_exporter_database_ssl else '' }}"
 
 # Additional environment variables to pass to the container
 #


### PR DESCRIPTION
Postgres connection string got messed up in https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-postgres-exporter/commit/b7d2b4004e71803ecb2acc5a3121eef3fb8e6a01, this fixes it.